### PR TITLE
compile on unsupported OSes.

### DIFF
--- a/tcpkeepalive_stub.go
+++ b/tcpkeepalive_stub.go
@@ -1,0 +1,19 @@
+// +build !linux
+
+package tcpkeepalive
+
+import (
+	"time"
+)
+
+func setIdle(fd uintptr, d time.Duration) error {
+	return nil
+}
+
+func setCount(fd uintptr, n int) error {
+	return nil
+}
+
+func setInterval(fd uintptr, d time.Duration) error {
+	return nil
+}


### PR DESCRIPTION
add a tcpkeepalive_stub.go file providing noop functions that will make it
compile also on unsupported OSes.